### PR TITLE
Feat: 게시글 좋아요 등록/취소/조회 API 구현

### DIFF
--- a/baekend/src/main/java/com/example/recifit/domain/like/controller/LikeController.java
+++ b/baekend/src/main/java/com/example/recifit/domain/like/controller/LikeController.java
@@ -1,0 +1,36 @@
+package com.example.recifit.domain.like.controller;
+
+import com.example.recifit.domain.like.dto.LikeResponseDto;
+import com.example.recifit.domain.like.service.LikeService;
+import com.example.recifit.global.common.CommonResponseDto;
+import com.example.recifit.global.common.SuccessCode;
+import com.example.recifit.global.security.MemberDetailsImpl;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/posts/{postId}")
+@Tag(name = "Like", description = "게시글, 댓글 좋아요 카운트 API")
+public class LikeController {
+
+    private final LikeService likeService;
+
+    public LikeController(LikeService likeService) {
+        this.likeService = likeService;
+    }
+
+    @PostMapping("/likes")
+    public ResponseEntity<CommonResponseDto<LikeResponseDto>> likeAddPost(@PathVariable Long postId,
+                                                                          @AuthenticationPrincipal MemberDetailsImpl memberDetailsImpl) {
+        Long memberId = memberDetailsImpl.getMember().getId();
+
+        LikeResponseDto likeResponseDto = likeService.likeAddPost(postId, memberId);
+
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.ADD_POST_LIKE, likeResponseDto));
+    }
+}

--- a/baekend/src/main/java/com/example/recifit/domain/like/controller/LikeController.java
+++ b/baekend/src/main/java/com/example/recifit/domain/like/controller/LikeController.java
@@ -2,6 +2,7 @@ package com.example.recifit.domain.like.controller;
 
 import com.example.recifit.domain.like.dto.LikeResponseDto;
 import com.example.recifit.domain.like.service.LikeService;
+import com.example.recifit.domain.post.dto.PostResponseDto;
 import com.example.recifit.global.common.CommonResponseDto;
 import com.example.recifit.global.common.SuccessCode;
 import com.example.recifit.global.security.MemberDetailsImpl;
@@ -39,5 +40,15 @@ public class LikeController {
         LikeResponseDto likeResponseDto = likeService.likeDeletePost(postId, memberId);
 
         return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.REMOVE_POST_LIKE_SUCCESS, likeResponseDto));
+    }
+
+    @GetMapping
+    public ResponseEntity<CommonResponseDto<PostResponseDto>> getPostLike(@PathVariable Long postId,
+                                                                          @AuthenticationPrincipal MemberDetailsImpl memberDetailsImpl) {
+        Long memberId = memberDetailsImpl != null ? memberDetailsImpl.getMember().getId() : null;
+
+        PostResponseDto postResponseDto = likeService.getPostLike(postId, memberId);
+
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.GET_POST_SUCCESS, postResponseDto));
     }
 }

--- a/baekend/src/main/java/com/example/recifit/domain/like/controller/LikeController.java
+++ b/baekend/src/main/java/com/example/recifit/domain/like/controller/LikeController.java
@@ -8,13 +8,10 @@ import com.example.recifit.global.security.MemberDetailsImpl;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/posts/{postId}")
+@RequestMapping("/likes/post/{postId}")
 @Tag(name = "Like", description = "게시글, 댓글 좋아요 카운트 API")
 public class LikeController {
 
@@ -24,13 +21,23 @@ public class LikeController {
         this.likeService = likeService;
     }
 
-    @PostMapping("/likes")
+    @PostMapping
     public ResponseEntity<CommonResponseDto<LikeResponseDto>> likeAddPost(@PathVariable Long postId,
                                                                           @AuthenticationPrincipal MemberDetailsImpl memberDetailsImpl) {
         Long memberId = memberDetailsImpl.getMember().getId();
 
         LikeResponseDto likeResponseDto = likeService.likeAddPost(postId, memberId);
 
-        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.ADD_POST_LIKE, likeResponseDto));
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.ADD_POST_LIKE_SUCCESS, likeResponseDto));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<CommonResponseDto<LikeResponseDto>> likeDeletePost(@PathVariable Long postId,
+                                                                             @AuthenticationPrincipal MemberDetailsImpl memberDetailsImpl) {
+        Long memberId = memberDetailsImpl.getMember().getId();
+
+        LikeResponseDto likeResponseDto = likeService.likeDeletePost(postId, memberId);
+
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.REMOVE_POST_LIKE_SUCCESS, likeResponseDto));
     }
 }

--- a/baekend/src/main/java/com/example/recifit/domain/like/dto/LikeResponseDto.java
+++ b/baekend/src/main/java/com/example/recifit/domain/like/dto/LikeResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.recifit.domain.like.dto;
+
+import lombok.Getter;
+
+
+@Getter
+public class LikeResponseDto {
+
+    private final boolean isLiked;      // 현재 내가 좋아요 중인지
+
+    private final Long postId;          // 좋아요 누른 게시글 ID
+
+    private final int likePostCount;        // 게시글 총 좋아요 수
+
+    public LikeResponseDto(boolean isLiked, Long postId, int likePostCount) {
+        this.isLiked = isLiked;
+        this.postId = postId;
+        this.likePostCount = likePostCount;
+    }
+}

--- a/baekend/src/main/java/com/example/recifit/domain/like/dto/LikeResponseDto.java
+++ b/baekend/src/main/java/com/example/recifit/domain/like/dto/LikeResponseDto.java
@@ -10,11 +10,15 @@ public class LikeResponseDto {
 
     private final Long postId;          // 좋아요 누른 게시글 ID
 
-    private final int likePostCount;        // 게시글 총 좋아요 수
+    private final int likeCount;        // 게시글 총 좋아요 수
 
-    public LikeResponseDto(boolean isLiked, Long postId, int likePostCount) {
+    private final boolean likedByMe;        // 내가 좋아요 눌렀는지 확인용
+
+    public LikeResponseDto(boolean isLiked, Long postId, int likeCount,
+                           boolean likedByMe) {
         this.isLiked = isLiked;
         this.postId = postId;
-        this.likePostCount = likePostCount;
+        this.likeCount = likeCount;
+        this.likedByMe = likedByMe;
     }
 }

--- a/baekend/src/main/java/com/example/recifit/domain/like/entity/Like.java
+++ b/baekend/src/main/java/com/example/recifit/domain/like/entity/Like.java
@@ -1,0 +1,41 @@
+package com.example.recifit.domain.like.entity;
+
+import com.example.recifit.domain.comment.entity.Comment;
+import com.example.recifit.domain.member.entity.Member;
+import com.example.recifit.domain.post.entity.Post;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@Table(name = "likes")
+@NoArgsConstructor
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Builder
+    public Like(Member member, Post post, Comment comment) {
+        this.member = member;
+        this.post = post;
+        this.comment = comment;
+    }
+}

--- a/baekend/src/main/java/com/example/recifit/domain/like/repository/LikeRepository.java
+++ b/baekend/src/main/java/com/example/recifit/domain/like/repository/LikeRepository.java
@@ -1,0 +1,12 @@
+package com.example.recifit.domain.like.repository;
+
+import com.example.recifit.domain.like.entity.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    boolean existsByPostIdAndMemberId(Long postId, Long memberId);
+}

--- a/baekend/src/main/java/com/example/recifit/domain/like/repository/LikeRepository.java
+++ b/baekend/src/main/java/com/example/recifit/domain/like/repository/LikeRepository.java
@@ -4,9 +4,13 @@ import com.example.recifit.domain.like.entity.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
     boolean existsByPostIdAndMemberId(Long postId, Long memberId);
+
+    Optional<Like> findByPostIdAndMemberId(Long postId, Long memberId);
 }

--- a/baekend/src/main/java/com/example/recifit/domain/like/service/LikeService.java
+++ b/baekend/src/main/java/com/example/recifit/domain/like/service/LikeService.java
@@ -5,6 +5,7 @@ import com.example.recifit.domain.like.entity.Like;
 import com.example.recifit.domain.like.repository.LikeRepository;
 import com.example.recifit.domain.member.entity.Member;
 import com.example.recifit.domain.member.repository.MemberRepository;
+import com.example.recifit.domain.post.dto.PostResponseDto;
 import com.example.recifit.domain.post.entity.Post;
 import com.example.recifit.domain.post.repository.PostRepository;
 import com.example.recifit.global.error.errorcode.ErrorCode;
@@ -89,5 +90,32 @@ public class LikeService {
         post.decrementPostLikeCount();
 
         return new LikeResponseDto(false, postId,post.getLikeCount(), false);
+    }
+
+    public PostResponseDto getPostLike(Long postId, Long memberId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        boolean likedByMe = false;
+        boolean mine = false;
+
+        if (memberId != null) {
+            likedByMe = likeRepository.existsByPostIdAndMemberId(postId, memberId);
+            mine = post.getMember() != null && memberId.equals(post.getMember().getId());
+        }
+
+        return new PostResponseDto(
+                post.getId(),
+                post.getMember() != null ? post.getMember().getId() : null,
+                post.getPostCategory(),
+                post.getTitle(),
+                post.getContent(),
+                post.getMember() != null ? post.getMember().getNickname() : null,
+                post.getLikeCount(),
+                post.getCommentCount(),
+                post.getCreatedAt(),
+                mine,
+                likedByMe
+        );
     }
 }

--- a/baekend/src/main/java/com/example/recifit/domain/like/service/LikeService.java
+++ b/baekend/src/main/java/com/example/recifit/domain/like/service/LikeService.java
@@ -1,0 +1,60 @@
+package com.example.recifit.domain.like.service;
+
+import com.example.recifit.domain.like.dto.LikeResponseDto;
+import com.example.recifit.domain.like.entity.Like;
+import com.example.recifit.domain.like.repository.LikeRepository;
+import com.example.recifit.domain.member.entity.Member;
+import com.example.recifit.domain.member.repository.MemberRepository;
+import com.example.recifit.domain.post.entity.Post;
+import com.example.recifit.domain.post.repository.PostRepository;
+import com.example.recifit.global.error.errorcode.ErrorCode;
+import com.example.recifit.global.error.exception.CustomException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    public LikeService(LikeRepository likeRepository,
+                       PostRepository postRepository,
+                       MemberRepository memberRepository) {
+        this.likeRepository = likeRepository;
+        this.postRepository = postRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public LikeResponseDto likeAddPost(Long postId, Long memberId) {
+
+        // 게시글이 있는지 확인
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // 좋아요 누른 멤버 확인
+        // 해당 멤버가 중복 좋아요를 눌렀는지 확인할 수 있음
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+
+        // 이미 좋아요 누른 상태라면 그대로 반환하기
+        if (likeRepository.existsByPostIdAndMemberId(postId, memberId)) {
+
+            return new LikeResponseDto(true, postId,post.getLikeCount());
+        }
+
+        Like like = likeRepository.save(Like.builder()
+                .member(member)
+                .post(post)
+                .build());
+
+        post.incrementPostLikeCount();
+
+        return new LikeResponseDto(true, postId,post.getLikeCount());
+    }
+}
+

--- a/baekend/src/main/java/com/example/recifit/domain/like/service/LikeService.java
+++ b/baekend/src/main/java/com/example/recifit/domain/like/service/LikeService.java
@@ -40,11 +40,13 @@ public class LikeService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-
         // 이미 좋아요 누른 상태라면 그대로 반환하기
         if (likeRepository.existsByPostIdAndMemberId(postId, memberId)) {
 
-            return new LikeResponseDto(true, postId,post.getLikeCount());
+
+            // 이 조건이 항상 true로 걸리니까, 새로운 Like를 만들지 않고 그대로 return 하고 있음.
+            // 즉, 카운트를 0으로 줄여도, 실제 likes 행이 남아 있기 때문에 "이미 좋아요 눌렀다" 라고 판단하고 있음.
+            return new LikeResponseDto(true, postId,post.getLikeCount(), true);
         }
 
         Like like = likeRepository.save(Like.builder()
@@ -54,7 +56,38 @@ public class LikeService {
 
         post.incrementPostLikeCount();
 
-        return new LikeResponseDto(true, postId,post.getLikeCount());
+        return new LikeResponseDto(true, postId,post.getLikeCount(), true);
+    }
+
+    @Transactional
+    public LikeResponseDto likeDeletePost(Long postId, Long memberId) {
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Like like = likeRepository.findByPostIdAndMemberId(postId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_LIKE_NOT_FOUND));
+
+        // 내가 좋아요한 것인지 확인 -> 예외 처리
+        if (!like.getMember().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.POST_LIKE_DELETE_FORBIDDEN);
+        }
+
+        if(!like.getPost().getId().equals(postId)) {
+            throw new CustomException(ErrorCode.POST_LIKE_DELETE_FORBIDDEN);
+        }
+
+        // 좋아요 눌렀는지 확인
+        likeRepository.findByPostIdAndMemberId(postId, memberId)
+                // null이 발생하면 실행되지 않음(.ifPresent())
+                .ifPresent(a -> {
+                    likeRepository.delete(like);         // 실제 Like 행 삭제
+                });
+        post.decrementPostLikeCount();
+
+        return new LikeResponseDto(false, postId,post.getLikeCount(), false);
     }
 }
-

--- a/baekend/src/main/java/com/example/recifit/domain/post/dto/PostResponseDto.java
+++ b/baekend/src/main/java/com/example/recifit/domain/post/dto/PostResponseDto.java
@@ -30,10 +30,12 @@ public class PostResponseDto {
 
     private boolean mine;
 
+    private boolean likedByMe;
+
     public PostResponseDto(Long id, Long memberId, PostCategory postCategory, String title,
                            String content, String nickname, int likeCount,
                            int commentCount, LocalDateTime createdAt,
-                           boolean mine) {
+                           boolean mine, boolean likedByMe) {
         this.id = id;
         this.memberId = memberId;
         this.postCategory = postCategory;
@@ -44,11 +46,15 @@ public class PostResponseDto {
         this.commentCount = commentCount;
         this.createdAt = createdAt;
         this.mine = mine;
+        this.likedByMe = likedByMe;
     }
 
-    public PostResponseDto(Long id, PostCategory postCategory, String title,
-                           String content, String nickname, int likeCount,
-                           int commentCount, LocalDateTime createdAt) {
-        this(id, null, postCategory, title, content, nickname, likeCount, commentCount, createdAt, false);
-    }
+//    public PostResponseDto(Long id, PostCategory postCategory, String title,
+//                           String content, String nickname, int likeCount,
+//                           int commentCount, LocalDateTime createdAt) {
+//        this(id, null, postCategory,
+//                title, content, nickname,
+//                likeCount, commentCount, createdAt,
+//                false, false);
+//    }
 }

--- a/baekend/src/main/java/com/example/recifit/domain/post/dto/PostResponseDto.java
+++ b/baekend/src/main/java/com/example/recifit/domain/post/dto/PostResponseDto.java
@@ -48,13 +48,4 @@ public class PostResponseDto {
         this.mine = mine;
         this.likedByMe = likedByMe;
     }
-
-//    public PostResponseDto(Long id, PostCategory postCategory, String title,
-//                           String content, String nickname, int likeCount,
-//                           int commentCount, LocalDateTime createdAt) {
-//        this(id, null, postCategory,
-//                title, content, nickname,
-//                likeCount, commentCount, createdAt,
-//                false, false);
-//    }
 }

--- a/baekend/src/main/java/com/example/recifit/domain/post/entity/Post.java
+++ b/baekend/src/main/java/com/example/recifit/domain/post/entity/Post.java
@@ -80,4 +80,16 @@ public class Post extends BaseEntity {
             this.commentCount--;
         }
     }
+
+    // 게시글 좋아요 수 증가
+    public void incrementPostLikeCount() {
+        this.likeCount++;
+    }
+
+    // 게시글 좋아요 수 감소
+    public void decrementPostLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
 }

--- a/baekend/src/main/java/com/example/recifit/global/common/SuccessCode.java
+++ b/baekend/src/main/java/com/example/recifit/global/common/SuccessCode.java
@@ -42,8 +42,8 @@ public enum SuccessCode {
     /**
      * 좋아요 관련 Code
      */
-    ADD_POST_LIKE("게시글 좋아요가 등록되었습니다.");
-
+    ADD_POST_LIKE_SUCCESS("게시글 좋아요가 등록되었습니다."),
+    REMOVE_POST_LIKE_SUCCESS("게시글 좋아요가 삭제되었습니다.");
 
 
     private final String message;

--- a/baekend/src/main/java/com/example/recifit/global/common/SuccessCode.java
+++ b/baekend/src/main/java/com/example/recifit/global/common/SuccessCode.java
@@ -37,7 +37,12 @@ public enum SuccessCode {
     /**
      * AI 레시피 추천 관련 Code
      */
-    AI_RECIPE_SUCCESS("AI 레시피 추천 성공");
+    AI_RECIPE_SUCCESS("AI 레시피 추천 성공"),
+
+    /**
+     * 좋아요 관련 Code
+     */
+    ADD_POST_LIKE("게시글 좋아요가 등록되었습니다.");
 
 
 

--- a/baekend/src/main/java/com/example/recifit/global/error/errorcode/ErrorCode.java
+++ b/baekend/src/main/java/com/example/recifit/global/error/errorcode/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "본인이 작성한 게시글만 삭제할 수 있습니다."),
     COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "본인이 작성한 댓글만 삭제할 수 있습니다."),
     NO_COMMENT_MODIFY_PERMISSION(HttpStatus.FORBIDDEN, "본인이 작성한 댓글만 수정할 수 있습니다."),
+    POST_LIKE_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 좋아요만 삭제할 수 있습니다."),
 
     /**
      * 404 NOT_FOUND
@@ -38,6 +39,7 @@ public enum ErrorCode {
     INGREDIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "재료를 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요를 찾을 수 없습니다."),
 
     /**
      * 500 INTERNAL_SERVER_ERROR


### PR DESCRIPTION
`POST /posts/{postId}/likes`

- 좋아요 추가 + 카운트 증가 로직 포함

`DELETE /posts/{postId}/likes`

- 좋아요 삭제 + 카운트 감소 로직 포함